### PR TITLE
feat: add abortAll in parallel client

### DIFF
--- a/src/interfaces/task-manager.ts
+++ b/src/interfaces/task-manager.ts
@@ -1,5 +1,7 @@
 export type ITaskStatus = 'busy' | 'pending' | 'finished' | 'deleted';
 
+export type ITaskCallback = (taskId: string, taskIndex: number, aborted?: boolean) => void;
+
 export interface ITask {
   id?: string;
   cb?: Function;

--- a/src/interfaces/task-manager.ts
+++ b/src/interfaces/task-manager.ts
@@ -1,10 +1,10 @@
 export type ITaskStatus = 'busy' | 'pending' | 'finished' | 'deleted';
 
-export type ITaskCallback = (taskId: string, taskIndex: number, aborted?: boolean) => void;
+export type ITaskCallback = (taskId: string, taskIndex: number) => void;
 
 export interface ITask {
   id?: string;
-  cb?: Function;
+  cb?: ITaskCallback;
   status?: ITaskStatus;
 }
 

--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -13,8 +13,6 @@ export interface IClientBaseMethods {
   connect(config: IConfig): Promise<void>;
   /**Disconnects from the server. Closes all opened sockets and streams.*/
   disconnect(): Promise<void>;
-  /**Aborts the current file transfer by reconnecting with the server.*/
-  abort(): Promise<void>;
   /**Lists files and folders in specified directory.*/
   readDir(path?: string): Promise<IFile[]>;
   /**Returns the size of a file.*/
@@ -45,6 +43,8 @@ export interface IClientBaseMethods {
 }
 
 interface IClientMethods extends IClientBaseMethods {
+  /**Aborts the current file transfer by reconnecting with the server.*/
+  abort(): Promise<void>;
   /**Downloads a remote file and and pipes it to a writable stream.*/
   download(path: string, dest: Writable, options?: ITransferOptions): Promise<ITransferStatus>;
   /**Uploads a local file from readable stream.*/

--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -7,6 +7,7 @@ import { formatFile, getFileTypeFromStats, getFileType, createFileName } from '.
 import { TaskManager } from './task-manager';
 import { SftpClient } from './sftp-client';
 import { TransferManager } from './transfer-manager';
+import { delay } from '../utils';
 
 export interface IClientBaseMethods {
   /**Connects to a server.*/
@@ -56,15 +57,17 @@ export declare interface Client {
   on(event: 'connected', listener: (context: Client) => void): this;
   /**Emitted when the client has disconnected from a server.*/
   on(event: 'disconnected', listener: (context: Client) => void): this;
+  /**Emitted when `Client.abort` is called.*/
+  on(event: 'abort', listener: (context: Client) => void): this;
   /**Emitted when a chunk of a file was read and sent.*/
   on(event: 'progress', listener: (progress: ITransferProgress, info: ITransferInfo) => void): this;
-  /**Emitted when any operation is aborted.*/
-  on(event: 'aborted', listener: (context: Client) => void): this;
+
   once(event: 'connected', listener: (context: Client) => void): this;
   once(event: 'disconnected', listener: (context: Client) => void): this;
   once(event: 'progress', listener: (progress: ITransferProgress, info: ITransferInfo) => void): this;
-  once(event: 'aborted', listener: (context: Client) => void): this;
-  removeListener(event: 'connected' | 'disconnected' | 'progress' | 'aborted', listener: Function): this;
+  once(event: 'abort', listener: (context: Client) => void): this;
+
+  removeListener(event: 'connected' | 'disconnected' | 'abort' | 'progress', listener: Function): this;
 }
 
 export class Client extends EventEmitter implements IClientMethods {
@@ -126,10 +129,10 @@ export class Client extends EventEmitter implements IClientMethods {
   }
 
   public async abort() {
+    this.emit('abort', this);
+
     await this.disconnect();
     await this.connect(this.config);
-
-    this.emit('aborted', this);
   }
 
   public download(path: string, dest: Writable, options?: ITransferOptions): Promise<ITransferStatus> {

--- a/src/models/parallel-client.ts
+++ b/src/models/parallel-client.ts
@@ -6,9 +6,6 @@ import { Client, IClientBaseMethods } from './client';
 import { TaskManager } from './task-manager';
 import { makeId, ensureExists } from '../utils';
 
-/**Aborts every file transfer.*/
-// abort(): Promise<void>;
-
 interface IParallelClientMethods extends IClientBaseMethods {
   /**Connects every client to the server.*/
   connect(config: IConfig): Promise<void>;

--- a/src/models/task-manager.ts
+++ b/src/models/task-manager.ts
@@ -102,7 +102,7 @@ export class TaskManager extends EventEmitter {
     this._queue.forEach(r => {
       if (r.status === 'pending') {
         r.status = 'deleted';
-        this.emit('abort', r.id);
+        this.emit(`abort-${r.id}`);
       }
     });
   }

--- a/src/utils/function.ts
+++ b/src/utils/function.ts
@@ -12,3 +12,9 @@ export const safeExec = async (f: Function, ...args: any): Promise<ITaskResponse
 
   return { data, error };
 }
+
+export const delay = (time: number) => {
+  return new Promise(resolve => {
+    setTimeout(resolve, time);
+  });
+}


### PR DESCRIPTION
This PR adds method `ParallelClient.abortAll`, which aborts every file transfer.