### PR TITLE
Fix: TypeError on formatFile() when UnixPermission undefined

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -41,8 +41,8 @@ export const formatFile = (file: FileInfo): IFile => {
 
   return {
     permissions: {
-      user: permissions.user,
-      group: permissions.group,
+      user: permissions?.user,
+      group: permissions?.group,
     },
     type: getFileType(type),
     ext: extname(name),


### PR DESCRIPTION
If permissions is undefined then formatFile() throw error TypeError: Cannot read property 'user' of undefined at Object.exports.formatFile.

`export const formatFile = (file: FileInfo): IFile => {
  const { permissions, name, size, user, group, type } = file;

  return {
    permissions: {
      user: permissions.user,
      group: permissions.group,
    },
    type: getFileType(type),
    ext: extname(name),
    name,
    size,
    user,
    group,
  };
};`

Fixed by adding optional chaining operator **?.**

`export const formatFile = (file: FileInfo): IFile => {
  const { permissions, name, size, user, group, type } = file;

  return {
    permissions: {
      user: permissions?.user,
      group: permissions?.group,
    },
    type: getFileType(type),
    ext: extname(name),
    name,
    size,
    user,
    group,
  };
};`